### PR TITLE
Switch to use config file for oauth2-proxy

### DIFF
--- a/jobs/oauth2-proxy/spec
+++ b/jobs/oauth2-proxy/spec
@@ -10,6 +10,7 @@ templates:
   helpers/ctl_setup.sh: helpers/ctl_setup.sh
   helpers/ctl_utils.sh: helpers/ctl_utils.sh
   config/cg-logo.png: config/cg-logo.png
+  config/oauth2-proxy.cfg.erb: config/oauth2-proxy.cfg
 
 properties:
   address:
@@ -30,3 +31,9 @@ properties:
     description: OAuth redirect URL
   oidc_issuer_url:
     descrption: OIDC issuer URL
+  scope:
+    description: OAuth Scope
+  oidc_groups_claim:
+    description: OAuth Group claim (default is groups)
+  allowed_groups:
+    description: Restrict login to members of a group

--- a/jobs/oauth2-proxy/templates/bin/ctl
+++ b/jobs/oauth2-proxy/templates/bin/ctl
@@ -17,16 +17,7 @@ case $1 in
     echo $$ > $PIDFILE
 
     exec chpst -u vcap:vcap /var/vcap/packages/oauth2-proxy/oauth2-proxy \
-        --http-address="<%= p('address') %>" \
-        --upstream="<%= p('upstream') %>" \
-        --provider="<%= p('provider') %>" \
-        --client-id="<%= p('client_id') %>" \
-        --client-secret="<%= p('client_secret') %>" \
-        --cookie-secret="<%= p('cookie_secret') %>" \
-        --email-domain="<%= p('email_domain') %>"  \
-        --custom-sign-in-logo=/var/vcap/jobs/oauth2-proxy/config/cg-logo.png \
-        <% if_p('redirect_url') do |redirect_url| %>--redirect-url="<%= redirect_url %>" <% end %> \
-        <% if_p('oidc_issuer_url') do |oidc_issuer_url| %>--oidc-issuer-url="<%= oidc_issuer_url %>" <% end %> \
+        --config=/var/vcap/jobs/oauth2-proxy/config/oauth2-proxy.cfg
         >>$LOG_DIR/$JOB_NAME.log 2>&1
 
     ;;

--- a/jobs/oauth2-proxy/templates/config/oauth2-proxy.cfg.erb
+++ b/jobs/oauth2-proxy/templates/config/oauth2-proxy.cfg.erb
@@ -1,0 +1,42 @@
+## OAuth2 Proxy Config File
+## https://github.com/oauth2-proxy/oauth2-proxy
+
+## <addr>:<port> to listen on for HTTP/HTTPS clients
+# http_address = "127.0.0.1:4180"
+# https_address = ":443"
+
+http_address = "<%= p('address') %>"
+
+
+## the http url(s) of the upstream endpoint
+upstream = "<%= p('upstream') %>"
+
+
+## provider config
+provider = "<%= p('provider') %>"
+client_id = "<%= p('client_id') %>"
+client_secret = "<%= p('client_secret') %>"
+cookie_secret = "<%= p('cookie_secret') %>"
+email_domain = "<%= p('email_domain') %>"
+custom_sign_in_logo = /var/vcap/jobs/oauth2-proxy/config/cg-logo.png
+
+<% if_p('scope') do %>
+scope = "<%= scope %>"
+<% end %>
+
+<% if_p('oidc_groups_claim') do %>
+oidc_groups_claim = "<%= oidc_groups_claim %>"
+<% end %>
+
+<% if_p('allowed_groups') do %>
+allowed_groups = "<%= allowed_groups %>"
+<% end %>
+
+
+<% if_p('redirect_url') do %>
+redirect_url = "<%= redirect_url %>"
+<% end %>
+
+<% if_p('oidc_issuer_url') do %>
+oidc_issuer_url = "<%= oidc_issuer_url %>"
+<% end %>


### PR DESCRIPTION
## Changes proposed in this pull request:

- Using config file so its easier manage and add new configs
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None 